### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/aidm_server/blueprints/players.py
+++ b/aidm_server/blueprints/players.py
@@ -1,6 +1,7 @@
 # players.py
 
 from flask import Blueprint, request, jsonify
+import logging
 from aidm_server.database import db
 from aidm_server.models import Player, Campaign
 
@@ -37,7 +38,8 @@ def add_player(campaign_id):
         }), 201
     except Exception as e:
         db.session.rollback()
-        return jsonify({"error": "Failed to create player", "details": str(e)}), 400
+        logging.error("Failed to create player: %s", str(e))
+        return jsonify({"error": "Failed to create player"}), 400
 
 def get_players(campaign_id):
     players = Player.query.filter_by(campaign_id=campaign_id).all()


### PR DESCRIPTION
Potential fix for [https://github.com/dreichner2/AIDM/security/code-scanning/1](https://github.com/dreichner2/AIDM/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the client. Instead, we should log the detailed error message on the server and return a generic error message to the client. This can be achieved by modifying the `add_player` function to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the line that returns the detailed error message with a line that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
